### PR TITLE
fix: return type of create roster template endpoint

### DIFF
--- a/cmd/src/pkg/handlers/roster_handler.go
+++ b/cmd/src/pkg/handlers/roster_handler.go
@@ -439,7 +439,7 @@ func (h *RosterHandler) GetSavedRoster(c *gin.Context) {
 //	@Accept		json
 //	@Produce	json
 //	@Param		params	body		models.RosterTemplateCreateRequest					false	"Template Params"
-//	@Success	200	{array}		models.SavedShift	"Created Template"
+//	@Success	200	{array}		models.RosterTemplate	"Created Template"
 //	@Failure	400	{string}	string				"Invalid request"
 //	@ID			createRosterTemplate
 //	@Router		/roster/template [post]


### PR DESCRIPTION
The return type before was a savedshift but this should be rostertemplate of course.