### PR TITLE
fix: lint and build workflow

### DIFF
--- a/.github/workflows/lint-and-build.yml
+++ b/.github/workflows/lint-and-build.yml
@@ -23,7 +23,7 @@ jobs:
       test: true
 
   build-and-lint-client:
-    uses: GEWIS/actions/.github/workflows/lint-and-build-yarn.yml@v1
+    uses: GEWIS/actions/.github/workflows/lint-and-build-npm.yml@v1
     with:
       node-version: "^22.0.0"
       lint: true


### PR DESCRIPTION
Fixes the lint and build workflow as it was using the yarn instead of npm.
