### PR TITLE
fix: package in client

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
     "lint:fix": "eslint --fix .",
     "format": "prettier --ignore-path .gitignore --check ./src/",
     "format:fix": "prettier --ignore-path .gitignore --write ./src",
-    "prepublishOnly": "yarn install --frozen-lockfile && yarn build"
+    "prepublishOnly": "npm ci && npm run build"
   },
   "type": "module",
   "license": "AGPL-3.0-only",


### PR DESCRIPTION
The package.json did not have the correct prepublishOnly it used yarn but should have used npm.

