### PR TITLE
feat: add mariadb possibility

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -7,5 +7,6 @@ CLIENT_SECRET=
 # Change to localhost:5173 when running everything local
 ALLOWED_ORIGINS=
 DATABASE=
+DATABASE_DSN=
 HOST=
 BASE_PATH=

--- a/cmd/src/pkg/database.go
+++ b/cmd/src/pkg/database.go
@@ -2,17 +2,33 @@ package database
 
 import (
 	"GEWIS-Rooster/cmd/src/pkg/models"
+	"gorm.io/driver/mysql"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
+	"os"
 )
 
 func ConnectDB(name string) *gorm.DB {
-	db, err := gorm.Open(sqlite.Open(name), &gorm.Config{})
+	devType := os.Getenv("DEV_TYPE")
+
+	var db *gorm.DB
+	var err error
+
+	if devType == "production" {
+		dsn := os.Getenv("DATABASE_DSN")
+		db, err = gorm.Open(mysql.Open(dsn), &gorm.Config{})
+	} else {
+		db, err = gorm.Open(sqlite.Open(name), &gorm.Config{})
+
+	}
+
 	if err != nil {
 		panic("failed to connect database")
 	}
 
-	db.Exec("PRAGMA foreign_keys = ON")
+	if devType != "production" {
+		db.Exec("PRAGMA foreign_keys = ON")
+	}
 
 	if err := db.AutoMigrate(&models.User{}, &models.Organ{}, &models.Roster{}, &models.RosterShift{}, &models.RosterAnswer{}, &models.SavedShift{}, &models.RosterTemplate{}); err != nil {
 		panic(err)


### PR DESCRIPTION
This feature adds the option in the ENV settings to add production. This means that it will use not SQLite as DB but MySQL/MariaDB.
