### PR TITLE
feat: shift user ordering

### DIFF
--- a/cmd/src/main.go
+++ b/cmd/src/main.go
@@ -25,7 +25,8 @@ import (
 func main() {
 	log.Print("Starting server")
 
-	if _, err := os.Stat(".env"); os.IsExist(err) {
+	if _, err := os.Stat(".env"); err == nil {
+		log.Print("Loading .env file")
 		if err := godotenv.Load(); err != nil {
 			log.Fatal().Msgf("Error loading .env file: %v", err)
 		}
@@ -50,7 +51,7 @@ func main() {
 	r := gin.Default()
 
 	r.Use(cors.New(cors.Config{
-		AllowOrigins:     []string{os.Getenv("ALLOWED_ORIGINS")}, // Frontend URL
+		AllowAllOrigins:  true, // Frontend URL
 		AllowMethods:     []string{"GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"},
 		AllowHeaders:     []string{"Content-Type", "Authorization"},
 		AllowCredentials: true, // If you need to support cookies or authentication

--- a/cmd/src/pkg/handlers/roster_handler.go
+++ b/cmd/src/pkg/handlers/roster_handler.go
@@ -423,13 +423,18 @@ func (h *RosterHandler) GetSavedRoster(c *gin.Context) {
 		return
 	}
 
-	savedShifts, err := h.rosterService.GetSavedRoster(uint(id))
+	savedShifts, savedShiftOrdering, err := h.rosterService.GetSavedRoster(uint(id))
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 		return
 	}
 
-	c.JSON(http.StatusOK, savedShifts)
+	response := models.SavedShiftResponse{
+		SavedShifts:        savedShifts,
+		SavedShiftOrdering: savedShiftOrdering,
+	}
+
+	c.JSON(http.StatusOK, response)
 }
 
 // CreateRosterTemplate

--- a/cmd/src/pkg/models/roster.go
+++ b/cmd/src/pkg/models/roster.go
@@ -59,6 +59,12 @@ type SavedShift struct {
 	Users []*User `json:"users" gorm:"many2many:user_shift_saved;"`
 } // @name SavedShift
 
+type SavedShiftOrdering struct {
+	ShiftName string `json:"shiftName"`
+
+	Users []*User `json:"users"`
+}
+
 type RosterTemplate struct {
 	BaseModel
 
@@ -108,6 +114,12 @@ type RosterAnswerUpdateRequest struct {
 type SavedShiftUpdateRequest struct {
 	UserIDs []uint `json:"users"`
 } // @name SavedShiftUpdateRequest
+
+type SavedShiftResponse struct {
+	SavedShifts []*SavedShift `json:"savedShifts"`
+
+	SavedShiftOrdering []*SavedShiftOrdering `json:"savedShiftOrdering"`
+}
 
 type RosterFilterParams struct {
 	ID      *uint      `form:"id"`

--- a/cmd/src/pkg/services/roster_service_test.go
+++ b/cmd/src/pkg/services/roster_service_test.go
@@ -571,7 +571,7 @@ func (suite *TestRosterSuite) TestUpdateSavedShift_Success() {
 	err := suite.service.SaveRoster(1)
 	assert.NoError(suite.T(), err)
 
-	savedShifts, _ := suite.service.GetSavedRoster(1)
+	savedShifts, _, _ := suite.service.GetSavedRoster(1)
 
 	updateParams := &models.SavedShiftUpdateRequest{
 		UserIDs: []uint{user.ID},
@@ -592,7 +592,7 @@ func (suite *TestRosterSuite) TestUpdateSavedShift_UserLoadFailure() {
 	err := suite.service.SaveRoster(1)
 	assert.NoError(suite.T(), err)
 
-	savedShifts, _ := suite.service.GetSavedRoster(1)
+	savedShifts, _, _ := suite.service.GetSavedRoster(1)
 
 	updateParams := &models.SavedShiftUpdateRequest{
 		UserIDs: []uint{99999, 99998},


### PR DESCRIPTION
Adds an extra reponse to the saved shifts endpoint. Namely it calculates the ordering of users based on the shifts that they have last done.

