### PR TITLE
feat: shift ordering

### DIFF
--- a/client/src/.openapi-generator/FILES
+++ b/client/src/.openapi-generator/FILES
@@ -17,6 +17,7 @@ docs/RosterCreateRequest.md
 docs/RosterShift.md
 docs/RosterShiftApi.md
 docs/RosterShiftCreateRequest.md
+docs/RosterShiftUpdateRequest.md
 docs/RosterTemplate.md
 docs/RosterTemplateCreateRequest.md
 docs/RosterTemplateShift.md

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -335,6 +335,12 @@ export interface RosterShift {
      * @type {number}
      * @memberof RosterShift
      */
+    'order'?: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof RosterShift
+     */
     'rosterId'?: number;
     /**
      * 
@@ -361,6 +367,19 @@ export interface RosterShiftCreateRequest {
      * @memberof RosterShiftCreateRequest
      */
     'rosterId'?: number;
+}
+/**
+ * 
+ * @export
+ * @interface RosterShiftUpdateRequest
+ */
+export interface RosterShiftUpdateRequest {
+    /**
+     * 
+     * @type {number}
+     * @memberof RosterShiftUpdateRequest
+     */
+    'ordering'?: number;
 }
 /**
  * 
@@ -1960,6 +1979,49 @@ export const RosterShiftApiAxiosParamCreator = function (configuration?: Configu
                 options: localVarRequestOptions,
             };
         },
+        /**
+         * 
+         * @summary Update a roster shift
+         * @param {number} id Roster Shift ID
+         * @param {RosterShiftUpdateRequest} updateParams Update input
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        updateRosterShift: async (id: number, updateParams: RosterShiftUpdateRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'id' is not null or undefined
+            assertParamExists('updateRosterShift', 'id', id)
+            // verify required parameter 'updateParams' is not null or undefined
+            assertParamExists('updateRosterShift', 'updateParams', updateParams)
+            const localVarPath = `/roster/shift/{id}`
+                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'PATCH', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerAuth required
+            await setApiKeyToObject(localVarHeaderParameter, "Authorization", configuration)
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(updateParams, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
     }
 };
 
@@ -1996,6 +2058,20 @@ export const RosterShiftApiFp = function(configuration?: Configuration) {
             const localVarOperationServerBasePath = operationServerMap['RosterShiftApi.deleteRosterShift']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
+        /**
+         * 
+         * @summary Update a roster shift
+         * @param {number} id Roster Shift ID
+         * @param {RosterShiftUpdateRequest} updateParams Update input
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async updateRosterShift(id: number, updateParams: RosterShiftUpdateRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<RosterShift>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updateRosterShift(id, updateParams, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['RosterShiftApi.updateRosterShift']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
     }
 };
 
@@ -2025,6 +2101,17 @@ export const RosterShiftApiFactory = function (configuration?: Configuration, ba
          */
         deleteRosterShift(id: number, options?: RawAxiosRequestConfig): AxiosPromise<string> {
             return localVarFp.deleteRosterShift(id, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @summary Update a roster shift
+         * @param {number} id Roster Shift ID
+         * @param {RosterShiftUpdateRequest} updateParams Update input
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        updateRosterShift(id: number, updateParams: RosterShiftUpdateRequest, options?: RawAxiosRequestConfig): AxiosPromise<RosterShift> {
+            return localVarFp.updateRosterShift(id, updateParams, options).then((request) => request(axios, basePath));
         },
     };
 };
@@ -2058,6 +2145,19 @@ export class RosterShiftApi extends BaseAPI {
      */
     public deleteRosterShift(id: number, options?: RawAxiosRequestConfig) {
         return RosterShiftApiFp(this.configuration).deleteRosterShift(id, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary Update a roster shift
+     * @param {number} id Roster Shift ID
+     * @param {RosterShiftUpdateRequest} updateParams Update input
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof RosterShiftApi
+     */
+    public updateRosterShift(id: number, updateParams: RosterShiftUpdateRequest, options?: RawAxiosRequestConfig) {
+        return RosterShiftApiFp(this.configuration).updateRosterShift(id, updateParams, options).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/client/src/docs/RosterShift.md
+++ b/client/src/docs/RosterShift.md
@@ -9,6 +9,7 @@ Name | Type | Description | Notes
 **deletedAt** | [**GormDeletedAt**](GormDeletedAt.md) |  | [optional] [default to undefined]
 **id** | **number** |  | [optional] [default to undefined]
 **name** | **string** |  | [optional] [default to undefined]
+**order** | **number** |  | [optional] [default to undefined]
 **rosterId** | **number** |  | [optional] [default to undefined]
 **updatedAt** | **string** |  | [optional] [default to undefined]
 
@@ -22,6 +23,7 @@ const instance: RosterShift = {
     deletedAt,
     id,
     name,
+    order,
     rosterId,
     updatedAt,
 };

--- a/client/src/docs/RosterShiftApi.md
+++ b/client/src/docs/RosterShiftApi.md
@@ -6,6 +6,7 @@ All URIs are relative to *http://localhost*
 |------------- | ------------- | -------------|
 |[**createRosterShift**](#createrostershift) | **POST** /roster/shift | Create a new roster shift|
 |[**deleteRosterShift**](#deleterostershift) | **DELETE** /roster/shift/{id} | Deletes a roster shift|
+|[**updateRosterShift**](#updaterostershift) | **PATCH** /roster/shift/{id} | Update a roster shift|
 
 # **createRosterShift**
 > RosterShift createRosterShift(createParams)
@@ -107,6 +108,62 @@ const { status, data } = await apiInstance.deleteRosterShift(
 |-------------|-------------|------------------|
 |**200** | OK |  -  |
 |**400** | Bad Request |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **updateRosterShift**
+> RosterShift updateRosterShift(updateParams)
+
+
+### Example
+
+```typescript
+import {
+    RosterShiftApi,
+    Configuration,
+    RosterShiftUpdateRequest
+} from './api';
+
+const configuration = new Configuration();
+const apiInstance = new RosterShiftApi(configuration);
+
+let id: number; //Roster Shift ID (default to undefined)
+let updateParams: RosterShiftUpdateRequest; //Update input
+
+const { status, data } = await apiInstance.updateRosterShift(
+    id,
+    updateParams
+);
+```
+
+### Parameters
+
+|Name | Type | Description  | Notes|
+|------------- | ------------- | ------------- | -------------|
+| **updateParams** | **RosterShiftUpdateRequest**| Update input | |
+| **id** | [**number**] | Roster Shift ID | defaults to undefined|
+
+
+### Return type
+
+**RosterShift**
+
+### Authorization
+
+[BearerAuth](../README.md#BearerAuth)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+|**200** | OK |  -  |
+|**400** | Bad Request |  -  |
+|**404** | Not Found |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/client/src/docs/RosterShiftUpdateRequest.md
+++ b/client/src/docs/RosterShiftUpdateRequest.md
@@ -1,0 +1,20 @@
+# RosterShiftUpdateRequest
+
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**ordering** | **number** |  | [optional] [default to undefined]
+
+## Example
+
+```typescript
+import { RosterShiftUpdateRequest } from './api';
+
+const instance: RosterShiftUpdateRequest = {
+    ordering,
+};
+```
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/cmd/src/docs/docs.go
+++ b/cmd/src/docs/docs.go
@@ -502,6 +502,62 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Roster Shift"
+                ],
+                "summary": "Update a roster shift",
+                "operationId": "updateRosterShift",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Roster Shift ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update input",
+                        "name": "updateParams",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/RosterShiftUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/RosterShift"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
             }
         },
         "/roster/template": {
@@ -1310,6 +1366,9 @@ const docTemplate = `{
                 "name": {
                     "type": "string"
                 },
+                "order": {
+                    "type": "integer"
+                },
                 "rosterId": {
                     "type": "integer"
                 },
@@ -1325,6 +1384,14 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "rosterId": {
+                    "type": "integer"
+                }
+            }
+        },
+        "RosterShiftUpdateRequest": {
+            "type": "object",
+            "properties": {
+                "ordering": {
                     "type": "integer"
                 }
             }

--- a/cmd/src/docs/swagger.json
+++ b/cmd/src/docs/swagger.json
@@ -494,6 +494,62 @@
                         }
                     }
                 }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Roster Shift"
+                ],
+                "summary": "Update a roster shift",
+                "operationId": "updateRosterShift",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Roster Shift ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update input",
+                        "name": "updateParams",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/RosterShiftUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/RosterShift"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
             }
         },
         "/roster/template": {
@@ -1302,6 +1358,9 @@
                 "name": {
                     "type": "string"
                 },
+                "order": {
+                    "type": "integer"
+                },
                 "rosterId": {
                     "type": "integer"
                 },
@@ -1317,6 +1376,14 @@
                     "type": "string"
                 },
                 "rosterId": {
+                    "type": "integer"
+                }
+            }
+        },
+        "RosterShiftUpdateRequest": {
+            "type": "object",
+            "properties": {
+                "ordering": {
                     "type": "integer"
                 }
             }

--- a/cmd/src/docs/swagger.yaml
+++ b/cmd/src/docs/swagger.yaml
@@ -110,6 +110,8 @@ definitions:
         type: integer
       name:
         type: string
+      order:
+        type: integer
       rosterId:
         type: integer
       updatedAt:
@@ -120,6 +122,11 @@ definitions:
       name:
         type: string
       rosterId:
+        type: integer
+    type: object
+  RosterShiftUpdateRequest:
+    properties:
+      ordering:
         type: integer
     type: object
   RosterTemplate:
@@ -708,6 +715,42 @@ paths:
       security:
       - BearerAuth: []
       summary: Deletes a roster shift
+      tags:
+      - Roster Shift
+    patch:
+      consumes:
+      - application/json
+      operationId: updateRosterShift
+      parameters:
+      - description: Roster Shift ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: Update input
+        in: body
+        name: updateParams
+        required: true
+        schema:
+          $ref: '#/definitions/RosterShiftUpdateRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/RosterShift'
+        "400":
+          description: Bad Request
+          schema:
+            type: string
+        "404":
+          description: Not Found
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Update a roster shift
       tags:
       - Roster Shift
   /roster/template:

--- a/cmd/src/pkg/models/roster.go
+++ b/cmd/src/pkg/models/roster.go
@@ -34,6 +34,8 @@ type RosterShift struct {
 	Name string `json:"name"`
 
 	RosterID uint `json:"rosterId"`
+
+	Order int `json:"order" gorm:"default:-1"`
 } // @name RosterShift
 
 type RosterAnswer struct {
@@ -107,6 +109,10 @@ type RosterShiftCreateRequest struct {
 
 	RosterID uint `json:"rosterId"`
 } // @name RosterShiftCreateRequest
+
+type RosterShiftUpdateRequest struct {
+	Ordering *int `json:"ordering"`
+} // @name RosterShiftUpdateRequest
 
 type RosterAnswerCreateRequest struct {
 	UserID uint `json:"userId"`

--- a/cmd/src/pkg/services/roster_service.go
+++ b/cmd/src/pkg/services/roster_service.go
@@ -19,6 +19,7 @@ type RosterServiceInterface interface {
 	DeleteRoster(ID uint) error
 
 	CreateRosterShift(*models.RosterShiftCreateRequest) (*models.RosterShift, error)
+	UpdateRosterShift(uint, *models.RosterShiftUpdateRequest) (*models.RosterShift, error)
 	DeleteRosterShift(ID uint) error
 	CreateRosterAnswer(*models.RosterAnswerCreateRequest) (*models.RosterAnswer, error)
 	UpdateRosterAnswer(uint, *models.RosterAnswerUpdateRequest) (*models.RosterAnswer, error)
@@ -167,6 +168,26 @@ func (s *RosterService) CreateRosterShift(createParams *models.RosterShiftCreate
 	}
 
 	if err := s.db.Create(&rosterShift).Error; err != nil {
+		return nil, err
+	}
+
+	return &rosterShift, nil
+}
+
+func (s *RosterService) UpdateRosterShift(ID uint, updateParams *models.RosterShiftUpdateRequest) (*models.RosterShift, error) {
+	var rosterShift models.RosterShift
+
+	if err := s.db.First(&rosterShift, ID).Error; err != nil {
+		return nil, err
+	}
+
+	updates := make(map[string]interface{})
+
+	if updateParams.Ordering != nil {
+		updates["ordering"] = updateParams.Ordering
+	}
+
+	if err := s.db.Model(&rosterShift).Updates(updates).Error; err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Adds shift ordering into the roster shifts, which by default is -1.. This will mean the frontend would have to default to ids but anything not negative means it is part of the ordering.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- New feature _(non-breaking change which adds functionality)_