### PR TITLE
fix: roster save check for existing shifts

### DIFF
--- a/cmd/src/pkg/services/roster_service.go
+++ b/cmd/src/pkg/services/roster_service.go
@@ -256,8 +256,16 @@ func (s *RosterService) SaveRoster(ID uint) error {
 	}
 
 	for _, shift := range roster.RosterShift {
-		if err := s.createSavedShift(roster.ID, &shift); err != nil {
-			return err
+		var existing models.SavedShift
+		err := s.db.Where("roster_id = ? AND roster_shift_id = ?", roster.ID, shift.ID).First(&existing).Error
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				if err := s.createSavedShift(roster.ID, &shift); err != nil {
+					return err
+				}
+			} else {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
This will make sure than when you unsave and save a shift again it will not remake the already existing shifts.

<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_
