### PR TITLE
fix: have shift order have no default

### DIFF
--- a/cmd/seeder/models/roster.go
+++ b/cmd/seeder/models/roster.go
@@ -52,9 +52,9 @@ func roster(db *gorm.DB, count int) []*models.Roster {
 func rosterShift(db *gorm.DB, roster []*models.Roster) {
 	for _, roster := range roster {
 		shifts := []models.RosterShift{
-			{Name: "Shift A", RosterID: roster.ID},
-			{Name: "Shift B", RosterID: roster.ID},
-			{Name: "Shift C", RosterID: roster.ID},
+			{Name: "Shift A", RosterID: roster.ID, Order: 0},
+			{Name: "Shift B", RosterID: roster.ID, Order: 1},
+			{Name: "Shift C", RosterID: roster.ID, Order: 2},
 		}
 
 		if err := db.Create(&shifts).Error; err != nil {

--- a/cmd/src/pkg/models/roster.go
+++ b/cmd/src/pkg/models/roster.go
@@ -35,7 +35,7 @@ type RosterShift struct {
 
 	RosterID uint `json:"rosterId"`
 
-	Order int `json:"order" gorm:"default:-1"`
+	Order uint `json:"order"`
 } // @name RosterShift
 
 type RosterAnswer struct {


### PR DESCRIPTION
It will not immediatly give something an order. This will break the DB and thus all rosters will have to be purged.

<!-- Provide a general summary of your changes in the title above. -->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Breaking change _(fix or feature that would cause existing functionality to change)_
