### PR TITLE
fix: foreign key constraint on roster shift answer

### DIFF
--- a/cmd/src/pkg/models/roster.go
+++ b/cmd/src/pkg/models/roster.go
@@ -35,6 +35,8 @@ type RosterShift struct {
 
 	RosterID uint `json:"rosterId"`
 
+	Roster *Roster `json:"-" gorm:"foreignKey:RosterID;constraint:OnDelete:CASCADE;"`
+
 	Order uint `json:"order"`
 } // @name RosterShift
 
@@ -44,6 +46,8 @@ type RosterAnswer struct {
 	UserID uint `json:"userId" gorm:"uniqueIndex:user_answer_idx"`
 
 	RosterID uint `json:"rosterId" gorm:"uniqueIndex:user_answer_idx"`
+
+	Roster *Roster `json:"roster" gorm:"foreignKey:RosterID;constraint:OnDelete:CASCADE;"`
 
 	RosterShiftID uint `json:"rosterShiftId" gorm:"uniqueIndex:user_answer_idx;"`
 


### PR DESCRIPTION
There was no correct foreignkey for the roster shift answers and shifts. So deleting a roster with answers was not possible.
