### PR TITLE
fix: shift group priorities endpoints

### DIFF
--- a/internal/roster/handler.go
+++ b/internal/roster/handler.go
@@ -35,7 +35,7 @@ func NewRosterHandler(rosterService Service, rg *gin.RouterGroup, db *gorm.DB) *
 	g.GET("/shift-groups/:id", h.GetShiftGroup)
 
 	g.GET("/shift-groups/:id/priority", requireShiftGroupOrganRoleParams(db, models.RoleAdmin), h.GetShiftGroupPriorities)
-	g.PUT("/shift-groups/:id/priority", requireShiftGroupOrganRoleParams(db, models.RoleAdmin))
+	g.PUT("/shift-groups/:id/priority", requireShiftGroupOrganRoleParams(db, models.RoleAdmin), h.UpdateShiftGroupPriority)
 
 	return h
 }
@@ -326,6 +326,6 @@ func (h *Handler) UpdateShiftGroupPriority(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-
+	log.Print(groupPriority)
 	c.JSON(http.StatusOK, groupPriority)
 }

--- a/internal/roster/service.go
+++ b/internal/roster/service.go
@@ -233,7 +233,7 @@ func (s *service) GetShiftGroup(ID uint) (*models.ShiftGroup, error) {
 
 func (s *service) GetShiftGroupPriorities(groupID uint) ([]*models.ShiftGroupPriority, error) {
 	var priorities []*models.ShiftGroupPriority
-	if err := s.db.Find(&priorities).Error; err != nil {
+	if err := s.db.Where("shift_group_id = ?", groupID).Find(&priorities).Error; err != nil {
 		return nil, err
 	}
 
@@ -262,7 +262,7 @@ func (s *service) UpdateShiftGroupPriority(groupID uint, params GroupPriorityUpd
 		return nil, err
 	}
 
-	return &newRecord, err
+	return &newRecord, nil
 }
 
 func (s *service) createSavedShift(rID uint, shift *models.RosterShift) error {


### PR DESCRIPTION
This fixes the last issues with the shift group priorities endpints. Such as not applying the correct filters and not adding the handler function to the route.

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_