### PR TITLE
ci: remove lint and build from client

### DIFF
--- a/.github/workflows/lint-and-build.yml
+++ b/.github/workflows/lint-and-build.yml
@@ -26,8 +26,6 @@ jobs:
     uses: GEWIS/actions/.github/workflows/lint-and-build-npm.yml@v1
     with:
       node-version: "^22.0.0"
-      lint: true
-      format: true
       build: true
       test: false
       working-directory: './client'


### PR DESCRIPTION
This would always fail as we do not lint and format the client as this is not neccessary. Hence they are now removed from the workflows.

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- CI/CD _(Changes to the CI/CD configuration)_