### PR TITLE
fix: bind body error in template creation

### DIFF
--- a/internal/roster/handler_template.go
+++ b/internal/roster/handler_template.go
@@ -4,6 +4,7 @@ import (
 	"GEWIS-Rooster/internal/models"
 	"errors"
 	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
 	"gorm.io/gorm"
 	"net/http"
 	"strconv"
@@ -39,14 +40,14 @@ func (h *Handler) registerTemplateRoutes(g *gin.RouterGroup, db *gorm.DB) {
 //	@ID			createRosterTemplate
 //	@Router		/roster/template [post]
 func (h *Handler) CreateRosterTemplate(c *gin.Context) {
-	var param *TemplateCreateRequest
+	var param TemplateCreateRequest
 
-	if err := c.ShouldBindJSON(&param); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request"})
+	if err := c.ShouldBindBodyWith(&param, binding.JSON); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request" + err.Error()})
 		return
 	}
 
-	createdTemplate, err := h.rosterService.CreateRosterTemplate(param)
+	createdTemplate, err := h.rosterService.CreateRosterTemplate(&param)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return


### PR DESCRIPTION
In the template check we did a shouldBindBodyWith but we did not use this in the handler itself thus resulting in an EOF error as there was no body anymore.

## Related issues/external references
<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->
closes:  #132 
## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_