### PR TITLE
fix: seed roster assignment values

### DIFF
--- a/cmd/seeder/seeder_models/roster.go
+++ b/cmd/seeder/seeder_models/roster.go
@@ -30,7 +30,7 @@ func roster(db *gorm.DB, count int) []*models.Roster {
 	var organs []*models.Organ
 	var rosters []*models.Roster
 	var templates []*models.RosterTemplate
-	var values = models.Values{"Ja", "X", "L", "Nee"}
+	var values = models.Values{"J", "X", "L", "N"}
 
 	if err := db.Find(&users).Error; err != nil {
 		log.Printf("Could not get users: %v\n", err)


### PR DESCRIPTION
The seeder had values of Ja and Nee, which where wrong as the FE checks for single letter values.

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_