### PR TITLE
feat: roster user comments

### DIFF
--- a/client/src/.openapi-generator/FILES
+++ b/client/src/.openapi-generator/FILES
@@ -7,6 +7,7 @@ configuration.ts
 docs/AnswerCreateRequest.md
 docs/AnswerUpdateRequest.md
 docs/AuthApi.md
+docs/CommentCreateRequest.md
 docs/ExportApi.md
 docs/GEWISRoosterInternalModelsGroupPriority.md
 docs/GEWISRoosterInternalModelsOrganRole.md
@@ -17,6 +18,8 @@ docs/Roster.md
 docs/RosterAnswer.md
 docs/RosterAnswerApi.md
 docs/RosterApi.md
+docs/RosterComment.md
+docs/RosterCommentApi.md
 docs/RosterCreateRequest.md
 docs/RosterShift.md
 docs/RosterShiftApi.md

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -70,6 +70,31 @@ export interface AnswerUpdateRequest {
 /**
  * 
  * @export
+ * @interface CommentCreateRequest
+ */
+export interface CommentCreateRequest {
+    /**
+     * 
+     * @type {string}
+     * @memberof CommentCreateRequest
+     */
+    'comment'?: string;
+    /**
+     * 
+     * @type {number}
+     * @memberof CommentCreateRequest
+     */
+    'rosterId'?: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof CommentCreateRequest
+     */
+    'userId'?: number;
+}
+/**
+ * 
+ * @export
  * @enum {number}
  */
 
@@ -282,6 +307,49 @@ export interface RosterAnswer {
      * @memberof RosterAnswer
      */
     'value'?: string;
+}
+/**
+ * 
+ * @export
+ * @interface RosterComment
+ */
+export interface RosterComment {
+    /**
+     * 
+     * @type {string}
+     * @memberof RosterComment
+     */
+    'comment'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof RosterComment
+     */
+    'createdAt'?: string;
+    /**
+     * 
+     * @type {number}
+     * @memberof RosterComment
+     */
+    'id'?: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof RosterComment
+     */
+    'rosterId'?: number;
+    /**
+     * 
+     * @type {string}
+     * @memberof RosterComment
+     */
+    'updatedAt'?: string;
+    /**
+     * 
+     * @type {number}
+     * @memberof RosterComment
+     */
+    'userId'?: number;
 }
 /**
  * 
@@ -3054,6 +3122,194 @@ export class RosterAnswerApi extends BaseAPI {
      */
     public updateRosterAnswer(id: number, updateParams: AnswerUpdateRequest, options?: RawAxiosRequestConfig) {
         return RosterAnswerApiFp(this.configuration).updateRosterAnswer(id, updateParams, options).then((request) => request(this.axios, this.basePath));
+    }
+}
+
+
+
+/**
+ * RosterCommentApi - axios parameter creator
+ * @export
+ */
+export const RosterCommentApiAxiosParamCreator = function (configuration?: Configuration) {
+    return {
+        /**
+         * 
+         * @summary Create a new roster comment
+         * @param {CommentCreateRequest} createParams Roster comment input
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createRosterComment: async (createParams: CommentCreateRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'createParams' is not null or undefined
+            assertParamExists('createRosterComment', 'createParams', createParams)
+            const localVarPath = `/roster/comment`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerAuth required
+            await setApiKeyToObject(localVarHeaderParameter, "Authorization", configuration)
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(createParams, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @summary Get all comments for a roster
+         * @param {number} rosterId Roster ID
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getRosterComments: async (rosterId: number, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'rosterId' is not null or undefined
+            assertParamExists('getRosterComments', 'rosterId', rosterId)
+            const localVarPath = `/roster/comment`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerAuth required
+            await setApiKeyToObject(localVarHeaderParameter, "Authorization", configuration)
+
+            if (rosterId !== undefined) {
+                localVarQueryParameter['rosterId'] = rosterId;
+            }
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+    }
+};
+
+/**
+ * RosterCommentApi - functional programming interface
+ * @export
+ */
+export const RosterCommentApiFp = function(configuration?: Configuration) {
+    const localVarAxiosParamCreator = RosterCommentApiAxiosParamCreator(configuration)
+    return {
+        /**
+         * 
+         * @summary Create a new roster comment
+         * @param {CommentCreateRequest} createParams Roster comment input
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async createRosterComment(createParams: CommentCreateRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<RosterComment>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.createRosterComment(createParams, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['RosterCommentApi.createRosterComment']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * 
+         * @summary Get all comments for a roster
+         * @param {number} rosterId Roster ID
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getRosterComments(rosterId: number, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<RosterComment>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getRosterComments(rosterId, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['RosterCommentApi.getRosterComments']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+    }
+};
+
+/**
+ * RosterCommentApi - factory interface
+ * @export
+ */
+export const RosterCommentApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
+    const localVarFp = RosterCommentApiFp(configuration)
+    return {
+        /**
+         * 
+         * @summary Create a new roster comment
+         * @param {CommentCreateRequest} createParams Roster comment input
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createRosterComment(createParams: CommentCreateRequest, options?: RawAxiosRequestConfig): AxiosPromise<RosterComment> {
+            return localVarFp.createRosterComment(createParams, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @summary Get all comments for a roster
+         * @param {number} rosterId Roster ID
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getRosterComments(rosterId: number, options?: RawAxiosRequestConfig): AxiosPromise<Array<RosterComment>> {
+            return localVarFp.getRosterComments(rosterId, options).then((request) => request(axios, basePath));
+        },
+    };
+};
+
+/**
+ * RosterCommentApi - object-oriented interface
+ * @export
+ * @class RosterCommentApi
+ * @extends {BaseAPI}
+ */
+export class RosterCommentApi extends BaseAPI {
+    /**
+     * 
+     * @summary Create a new roster comment
+     * @param {CommentCreateRequest} createParams Roster comment input
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof RosterCommentApi
+     */
+    public createRosterComment(createParams: CommentCreateRequest, options?: RawAxiosRequestConfig) {
+        return RosterCommentApiFp(this.configuration).createRosterComment(createParams, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary Get all comments for a roster
+     * @param {number} rosterId Roster ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof RosterCommentApi
+     */
+    public getRosterComments(rosterId: number, options?: RawAxiosRequestConfig) {
+        return RosterCommentApiFp(this.configuration).getRosterComments(rosterId, options).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/client/src/docs/CommentCreateRequest.md
+++ b/client/src/docs/CommentCreateRequest.md
@@ -1,0 +1,24 @@
+# CommentCreateRequest
+
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**comment** | **string** |  | [optional] [default to undefined]
+**rosterId** | **number** |  | [optional] [default to undefined]
+**userId** | **number** |  | [optional] [default to undefined]
+
+## Example
+
+```typescript
+import { CommentCreateRequest } from './api';
+
+const instance: CommentCreateRequest = {
+    comment,
+    rosterId,
+    userId,
+};
+```
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/client/src/docs/RosterComment.md
+++ b/client/src/docs/RosterComment.md
@@ -1,0 +1,30 @@
+# RosterComment
+
+
+## Properties
+
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**comment** | **string** |  | [optional] [default to undefined]
+**createdAt** | **string** |  | [optional] [default to undefined]
+**id** | **number** |  | [optional] [default to undefined]
+**rosterId** | **number** |  | [optional] [default to undefined]
+**updatedAt** | **string** |  | [optional] [default to undefined]
+**userId** | **number** |  | [optional] [default to undefined]
+
+## Example
+
+```typescript
+import { RosterComment } from './api';
+
+const instance: RosterComment = {
+    comment,
+    createdAt,
+    id,
+    rosterId,
+    updatedAt,
+    userId,
+};
+```
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/client/src/docs/RosterCommentApi.md
+++ b/client/src/docs/RosterCommentApi.md
@@ -1,0 +1,115 @@
+# RosterCommentApi
+
+All URIs are relative to *http://localhost*
+
+|Method | HTTP request | Description|
+|------------- | ------------- | -------------|
+|[**createRosterComment**](#createrostercomment) | **POST** /roster/comment | Create a new roster comment|
+|[**getRosterComments**](#getrostercomments) | **GET** /roster/comment | Get all comments for a roster|
+
+# **createRosterComment**
+> RosterComment createRosterComment(createParams)
+
+
+### Example
+
+```typescript
+import {
+    RosterCommentApi,
+    Configuration,
+    CommentCreateRequest
+} from './api';
+
+const configuration = new Configuration();
+const apiInstance = new RosterCommentApi(configuration);
+
+let createParams: CommentCreateRequest; //Roster comment input
+
+const { status, data } = await apiInstance.createRosterComment(
+    createParams
+);
+```
+
+### Parameters
+
+|Name | Type | Description  | Notes|
+|------------- | ------------- | ------------- | -------------|
+| **createParams** | **CommentCreateRequest**| Roster comment input | |
+
+
+### Return type
+
+**RosterComment**
+
+### Authorization
+
+[BearerAuth](../README.md#BearerAuth)
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+|**201** | Created |  -  |
+|**400** | Bad Request |  -  |
+|**403** | Forbidden |  -  |
+|**404** | Not Found |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **getRosterComments**
+> Array<RosterComment> getRosterComments()
+
+
+### Example
+
+```typescript
+import {
+    RosterCommentApi,
+    Configuration
+} from './api';
+
+const configuration = new Configuration();
+const apiInstance = new RosterCommentApi(configuration);
+
+let rosterId: number; //Roster ID (default to undefined)
+
+const { status, data } = await apiInstance.getRosterComments(
+    rosterId
+);
+```
+
+### Parameters
+
+|Name | Type | Description  | Notes|
+|------------- | ------------- | ------------- | -------------|
+| **rosterId** | [**number**] | Roster ID | defaults to undefined|
+
+
+### Return type
+
+**Array<RosterComment>**
+
+### Authorization
+
+[BearerAuth](../README.md#BearerAuth)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+|**200** | OK |  -  |
+|**400** | Bad Request |  -  |
+|**404** | Not Found |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+

--- a/cmd/seeder/seeder/seeder.go
+++ b/cmd/seeder/seeder/seeder.go
@@ -63,6 +63,7 @@ func Seeder(name string) *gorm.DB {
 			&models.RosterTemplateShiftPreference{},
 			&models.ShiftGroup{},
 			&models.ShiftGroupPriority{},
+			&models.RosterComment{},
 		); err != nil {
 			panic(err)
 		}

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -602,6 +602,113 @@ const docTemplate = `{
                 }
             }
         },
+        "/roster/comment": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Roster Comment"
+                ],
+                "summary": "Get all comments for a roster",
+                "operationId": "getRosterComments",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Roster ID",
+                        "name": "rosterId",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RosterComment"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Roster Comment"
+                ],
+                "summary": "Create a new roster comment",
+                "operationId": "createRosterComment",
+                "parameters": [
+                    {
+                        "description": "Roster comment input",
+                        "name": "createParams",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/CommentCreateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/RosterComment"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/roster/saved-shift/{id}": {
             "get": {
                 "security": [
@@ -2005,6 +2112,20 @@ const docTemplate = `{
                 }
             }
         },
+        "CommentCreateRequest": {
+            "type": "object",
+            "properties": {
+                "comment": {
+                    "type": "string"
+                },
+                "rosterId": {
+                    "type": "integer"
+                },
+                "userId": {
+                    "type": "integer"
+                }
+            }
+        },
         "GEWIS-Rooster_internal_models.GroupPriority": {
             "type": "integer",
             "enum": [
@@ -2145,6 +2266,29 @@ const docTemplate = `{
                 },
                 "value": {
                     "type": "string"
+                }
+            }
+        },
+        "RosterComment": {
+            "type": "object",
+            "properties": {
+                "comment": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "rosterId": {
+                    "type": "integer"
+                },
+                "updatedAt": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -594,6 +594,113 @@
                 }
             }
         },
+        "/roster/comment": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Roster Comment"
+                ],
+                "summary": "Get all comments for a roster",
+                "operationId": "getRosterComments",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Roster ID",
+                        "name": "rosterId",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RosterComment"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Roster Comment"
+                ],
+                "summary": "Create a new roster comment",
+                "operationId": "createRosterComment",
+                "parameters": [
+                    {
+                        "description": "Roster comment input",
+                        "name": "createParams",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/CommentCreateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/RosterComment"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/roster/saved-shift/{id}": {
             "get": {
                 "security": [
@@ -1997,6 +2104,20 @@
                 }
             }
         },
+        "CommentCreateRequest": {
+            "type": "object",
+            "properties": {
+                "comment": {
+                    "type": "string"
+                },
+                "rosterId": {
+                    "type": "integer"
+                },
+                "userId": {
+                    "type": "integer"
+                }
+            }
+        },
         "GEWIS-Rooster_internal_models.GroupPriority": {
             "type": "integer",
             "enum": [
@@ -2137,6 +2258,29 @@
                 },
                 "value": {
                     "type": "string"
+                }
+            }
+        },
+        "RosterComment": {
+            "type": "object",
+            "properties": {
+                "comment": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "rosterId": {
+                    "type": "integer"
+                },
+                "updatedAt": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -15,6 +15,15 @@ definitions:
       value:
         type: string
     type: object
+  CommentCreateRequest:
+    properties:
+      comment:
+        type: string
+      rosterId:
+        type: integer
+      userId:
+        type: integer
+    type: object
   GEWIS-Rooster_internal_models.GroupPriority:
     enum:
     - 1
@@ -112,6 +121,21 @@ definitions:
         type: integer
       value:
         type: string
+    type: object
+  RosterComment:
+    properties:
+      comment:
+        type: string
+      createdAt:
+        type: string
+      id:
+        type: integer
+      rosterId:
+        type: integer
+      updatedAt:
+        type: string
+      userId:
+        type: integer
     type: object
   RosterCreateRequest:
     properties:
@@ -938,6 +962,74 @@ paths:
       summary: Updates a roster answer with the new value
       tags:
       - Roster Answer
+  /roster/comment:
+    get:
+      consumes:
+      - application/json
+      operationId: getRosterComments
+      parameters:
+      - description: Roster ID
+        in: query
+        name: rosterId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/RosterComment'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            type: string
+        "404":
+          description: Not Found
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Get all comments for a roster
+      tags:
+      - Roster Comment
+    post:
+      consumes:
+      - application/json
+      operationId: createRosterComment
+      parameters:
+      - description: Roster comment input
+        in: body
+        name: createParams
+        required: true
+        schema:
+          $ref: '#/definitions/CommentCreateRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/RosterComment'
+        "400":
+          description: Bad Request
+          schema:
+            type: string
+        "403":
+          description: Forbidden
+          schema:
+            type: string
+        "404":
+          description: Not Found
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Create a new roster comment
+      tags:
+      - Roster Comment
   /roster/saved-shift/{id}:
     get:
       consumes:

--- a/go.mod
+++ b/go.mod
@@ -9,12 +9,14 @@ require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
+	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
 	github.com/joho/godotenv v1.5.1
 	github.com/rs/zerolog v1.34.0
 	github.com/stretchr/testify v1.10.0
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.0
 	github.com/swaggo/swag v1.16.4
+	golang.org/x/image v0.38.0
 	golang.org/x/oauth2 v0.30.0
 	gorm.io/datatypes v1.2.6
 	gorm.io/driver/mysql v1.5.6
@@ -41,7 +43,6 @@ require (
 	github.com/go-playground/validator/v10 v10.26.0 // indirect
 	github.com/go-sql-driver/mysql v1.8.1 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
-	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
@@ -61,7 +62,6 @@ require (
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	golang.org/x/arch v0.16.0 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
-	golang.org/x/image v0.38.0 // indirect
 	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.35.0 // indirect

--- a/internal/models/roster.go
+++ b/internal/models/roster.go
@@ -149,3 +149,15 @@ type ShiftGroupPriority struct {
 
 	Priority GroupPriority `json:"priority" gorm:"type:smallint;default:2"`
 } // @name ShiftGroupPriority
+
+type RosterComment struct {
+	BaseModel
+
+	RosterID uint `json:"rosterId" gorm:"not null"`
+	Roster   Roster `json:"-" gorm:"foreignKey:RosterID;constraint:OnDelete:CASCADE;"`
+
+	UserID uint `json:"userId" gorm:"not null"`
+	User   User `json:"-" gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE;"`
+
+	Comment string `json:"comment" gorm:"type:text"`
+} // @name RosterComment

--- a/internal/platform/database/database.go
+++ b/internal/platform/database/database.go
@@ -57,6 +57,7 @@ func ConnectDB(name string) *gorm.DB {
 			&models.RosterTemplateShift{},
 			&models.RosterTemplateShiftPreference{},
 			&models.ShiftGroup{},
+			&models.RosterComment{},
 		); err != nil {
 			panic(err)
 		}

--- a/internal/platform/database/migrations/000005_add_roster_comments.down.sql
+++ b/internal/platform/database/migrations/000005_add_roster_comments.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE roster_comments;

--- a/internal/platform/database/migrations/000005_add_roster_comments.up.sql
+++ b/internal/platform/database/migrations/000005_add_roster_comments.up.sql
@@ -1,0 +1,18 @@
+CREATE TABLE `roster_comments` (
+    `id` BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    `created_at` datetime(3) DEFAULT NULL,
+    `updated_at` datetime(3) DEFAULT NULL,
+    `roster_id` BIGINT UNSIGNED NOT NULL,
+    `user_id` BIGINT UNSIGNED NOT NULL,
+    `comment` TEXT,
+
+    CONSTRAINT `fk_roster_comments_roster`
+        FOREIGN KEY (`roster_id`)
+            REFERENCES `rosters`(`id`)
+            ON DELETE CASCADE,
+
+    CONSTRAINT `fk_roster_comments_user`
+        FOREIGN KEY (`user_id`)
+            REFERENCES `users`(`id`)
+            ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/internal/roster/dto.go
+++ b/internal/roster/dto.go
@@ -51,6 +51,14 @@ type AnswerUpdateRequest struct {
 	Value string `json:"value"`
 } // @name AnswerUpdateRequest
 
+type CommentCreateRequest struct {
+	RosterID uint `json:"rosterId"`
+
+	UserID uint `json:"userId"`
+
+	Comment string `json:"comment"`
+} // @name CommentCreateRequest
+
 type SavedShiftUpdateRequest struct {
 	UserIDs []uint `json:"users"`
 } // @name SavedShiftUpdateRequest

--- a/internal/roster/handler.go
+++ b/internal/roster/handler.go
@@ -23,6 +23,7 @@ func NewRosterHandler(rosterService Service, rg *gin.RouterGroup, db *gorm.DB) *
 	h.registerRosterRoutes(g, db)
 	h.registerShiftRoutes(g, db)
 	h.registerTemplateRoutes(g, db)
+	h.registerCommentRoutes(g, db)
 
 	g.POST("/:id/fill", requireRosterOrganRoleParam(db, "id", models.RoleAdmin), h.FillRosterPreferences)
 

--- a/internal/roster/handler_comment.go
+++ b/internal/roster/handler_comment.go
@@ -1,0 +1,137 @@
+package roster
+
+import (
+	"GEWIS-Rooster/internal/models"
+	"errors"
+	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
+	"gorm.io/gorm"
+	"net/http"
+	"strconv"
+)
+
+func (h *Handler) registerCommentRoutes(g *gin.RouterGroup, db *gorm.DB) {
+	commentGroup := g.Group("/comment")
+	{
+		commentGroup.POST("", requireCommentOrganRoleBody(db, models.RoleMember), h.CreateRosterComment)
+		commentGroup.GET("", requireCommentOrganRoleQuery(db, "rosterId", models.RoleMember), h.GetRosterComments)
+	}
+}
+
+// CreateRosterComment
+//
+//	@Summary	Create a new roster comment
+//	@Security	BearerAuth
+//	@Tags		Roster Comment
+//	@Accept		json
+//	@Produce	json
+//	@Param		createParams	body		CommentCreateRequest	true	"Roster comment input"
+//	@Success	201				{object}	models.RosterComment
+//	@Failure	400				{string}	string
+//	@Failure	403				{string}	string
+//	@Failure	404				{string}	string
+//	@ID			createRosterComment
+//	@Router		/roster/comment [post]
+func (h *Handler) CreateRosterComment(c *gin.Context) {
+	var param *CommentCreateRequest
+
+	if err := c.ShouldBindBodyWith(&param, binding.JSON); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request"})
+		return
+	}
+
+	callerID, exists := c.Get("userID")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+
+	if callerID.(uint) != param.UserID {
+		c.JSON(http.StatusForbidden, gin.H{"error": "You can only comment on your own roster entry"})
+		return
+	}
+
+	createdComment, err := h.rosterService.CreateRosterComment(param)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Roster not found"})
+			return
+		}
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusCreated, createdComment)
+}
+
+// GetRosterComments
+//
+//	@Summary	Get all comments for a roster
+//	@Security	BearerAuth
+//	@Tags		Roster Comment
+//	@Accept		json
+//	@Produce	json
+//	@Param		rosterId	query		int	true	"Roster ID"
+//	@Success	200			{array}		models.RosterComment
+//	@Failure	400			{string}	string
+//	@Failure	404			{string}	string
+//	@ID			getRosterComments
+//	@Router		/roster/comment [get]
+func (h *Handler) GetRosterComments(c *gin.Context) {
+	rosterID, err := strconv.ParseUint(c.Query("rosterId"), 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid roster ID"})
+		return
+	}
+
+	comments, err := h.rosterService.GetRosterComments(uint(rosterID))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, comments)
+}
+
+// requireCommentOrganRoleBody validates the existence of a roster referenced
+// by rosterId in the JSON body and ensures the current user has the required
+// minimum role within that roster's organization.
+func requireCommentOrganRoleBody(db *gorm.DB, minRole models.OrganRole) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var body struct {
+			RosterID uint `json:"rosterId"`
+		}
+		if err := c.ShouldBindBodyWith(&body, binding.JSON); err != nil || body.RosterID == 0 {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Valid rosterId is required in body"})
+			return
+		}
+
+		var roster models.Roster
+		if err := db.First(&roster, "id = ?", body.RosterID).Error; err != nil {
+			c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "Roster not found"})
+			return
+		}
+		checkAccess(c, db, roster.OrganID, minRole)
+	}
+}
+
+// requireCommentOrganRoleQuery validates the existence of a roster referenced
+// by the given query parameter and ensures the current user has the required
+// minimum role within that roster's organization.
+func requireCommentOrganRoleQuery(db *gorm.DB, queryStr string, minRole models.OrganRole) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		rosterID := c.Query(queryStr)
+		if rosterID == "" {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": queryStr + " is required"})
+			return
+		}
+
+		var roster models.Roster
+		if err := db.First(&roster, "id = ?", rosterID).Error; err != nil {
+			c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "Roster not found"})
+			return
+		}
+
+		checkAccess(c, db, roster.OrganID, minRole)
+	}
+}

--- a/internal/roster/service.go
+++ b/internal/roster/service.go
@@ -14,6 +14,7 @@ type Service interface {
 	RosterManager
 	ShiftManager
 	TemplateManager
+	CommentManager
 
 	FillRosterPreferences(uint) ([]*models.RosterAnswer, error)
 

--- a/internal/roster/service_comment.go
+++ b/internal/roster/service_comment.go
@@ -1,0 +1,49 @@
+package roster
+
+import (
+	"GEWIS-Rooster/internal/models"
+	"errors"
+	"fmt"
+	"gorm.io/gorm"
+)
+
+type CommentManager interface {
+	CreateRosterComment(*CommentCreateRequest) (*models.RosterComment, error)
+	GetRosterComments(rosterID uint) ([]*models.RosterComment, error)
+}
+
+func (s *service) CreateRosterComment(params *CommentCreateRequest) (*models.RosterComment, error) {
+	var roster *models.Roster
+	if err := s.db.First(&roster, params.RosterID).Error; err != nil {
+		return nil, fmt.Errorf("roster not found: %w", err)
+	}
+
+	var answer models.RosterAnswer
+	if err := s.db.Where("user_id = ? AND roster_id = ?", params.UserID, params.RosterID).First(&answer).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, errors.New("user is not part of this roster")
+		}
+		return nil, err
+	}
+
+	comment := models.RosterComment{
+		RosterID: roster.ID,
+		UserID:   params.UserID,
+		Comment:  params.Comment,
+	}
+
+	if err := s.db.Create(&comment).Error; err != nil {
+		return nil, err
+	}
+
+	return &comment, nil
+}
+
+func (s *service) GetRosterComments(rosterID uint) ([]*models.RosterComment, error) {
+	var comments []*models.RosterComment
+	if err := s.db.Where("roster_id = ?", rosterID).Find(&comments).Error; err != nil {
+		return nil, err
+	}
+
+	return comments, nil
+}

--- a/internal/roster/service_comment_test.go
+++ b/internal/roster/service_comment_test.go
@@ -1,0 +1,112 @@
+package roster
+
+import (
+	"GEWIS-Rooster/internal/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func (suite *TestRosterSuite) TestCreateRosterComment_Valid() {
+	roster := models.Roster{
+		Name:    "Test Roster",
+		Values:  []string{"yes", "no"},
+		OrganID: uint(1),
+	}
+	suite.db.Create(&roster)
+
+	shift := models.RosterShift{
+		RosterID: roster.ID,
+	}
+	suite.db.Create(&shift)
+
+	answer := models.RosterAnswer{
+		UserID:        1,
+		RosterID:      roster.ID,
+		RosterShiftID: shift.ID,
+		Value:         "yes",
+	}
+	suite.db.Create(&answer)
+
+	createParams := &CommentCreateRequest{
+		RosterID: roster.ID,
+		UserID:   1,
+		Comment:  "I can't work this shift",
+	}
+
+	comment, err := suite.service.CreateRosterComment(createParams)
+
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), comment)
+	assert.Equal(suite.T(), createParams.Comment, comment.Comment)
+	assert.Equal(suite.T(), createParams.UserID, comment.UserID)
+	assert.Equal(suite.T(), roster.ID, comment.RosterID)
+}
+
+func (suite *TestRosterSuite) TestCreateRosterComment_UserNotInRoster() {
+	roster := models.Roster{
+		Name:    "Test Roster",
+		Values:  []string{"yes", "no"},
+		OrganID: uint(1),
+	}
+	suite.db.Create(&roster)
+
+	createParams := &CommentCreateRequest{
+		RosterID: roster.ID,
+		UserID:   1,
+		Comment:  "I can't work this shift",
+	}
+
+	comment, err := suite.service.CreateRosterComment(createParams)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), comment)
+	assert.Contains(suite.T(), err.Error(), "not part of this roster")
+}
+
+func (suite *TestRosterSuite) TestCreateRosterComment_RosterNotFound() {
+	createParams := &CommentCreateRequest{
+		RosterID: 9999,
+		UserID:   1,
+		Comment:  "I can't work this shift",
+	}
+
+	comment, err := suite.service.CreateRosterComment(createParams)
+
+	assert.Error(suite.T(), err)
+	assert.Nil(suite.T(), comment)
+	assert.Contains(suite.T(), err.Error(), "roster not found")
+}
+
+func (suite *TestRosterSuite) TestGetRosterComments_FiltersByRoster() {
+	rosterOne := models.Roster{
+		Name:    "Roster One",
+		Values:  []string{"yes", "no"},
+		OrganID: uint(1),
+	}
+	suite.db.Create(&rosterOne)
+
+	rosterTwo := models.Roster{
+		Name:    "Roster Two",
+		Values:  []string{"yes", "no"},
+		OrganID: uint(1),
+	}
+	suite.db.Create(&rosterTwo)
+
+	shiftOne := models.RosterShift{RosterID: rosterOne.ID}
+	suite.db.Create(&shiftOne)
+	shiftTwo := models.RosterShift{RosterID: rosterTwo.ID}
+	suite.db.Create(&shiftTwo)
+
+	suite.db.Create(&models.RosterAnswer{UserID: 1, RosterID: rosterOne.ID, RosterShiftID: shiftOne.ID, Value: "yes"})
+	suite.db.Create(&models.RosterAnswer{UserID: 1, RosterID: rosterTwo.ID, RosterShiftID: shiftTwo.ID, Value: "yes"})
+
+	_, err := suite.service.CreateRosterComment(&CommentCreateRequest{RosterID: rosterOne.ID, UserID: 1, Comment: "comment one"})
+	assert.NoError(suite.T(), err)
+	_, err = suite.service.CreateRosterComment(&CommentCreateRequest{RosterID: rosterTwo.ID, UserID: 1, Comment: "comment two"})
+	assert.NoError(suite.T(), err)
+
+	comments, err := suite.service.GetRosterComments(rosterOne.ID)
+
+	assert.NoError(suite.T(), err)
+	assert.Len(suite.T(), comments, 1)
+	assert.Equal(suite.T(), "comment one", comments[0].Comment)
+}


### PR DESCRIPTION
## Summary
- Add a `RosterComment` endpoint so a user can leave a comment on a roster tied to their own roster entry (e.g. to note why they can't work a shift)
- Creation is gated by the existing organ-membership check, a new check that the user has actually answered (`RosterAnswer`) for that roster, and is restricted to the calling user commenting on themselves
- Adds the `POST /roster/comment` and `GET /roster/comment` endpoints, DB migration/AutoMigrate wiring, and service tests
- Regenerates the API client and swagger docs for the new endpoints

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (includes new `service_comment_test.go` coverage: valid create, user-not-in-roster rejection, roster-not-found, and list-by-roster filtering)
- [ ] Manually exercise `POST /roster/comment` and `GET /roster/comment?rosterId=` against a running server