### PR TITLE
fix: comment request not having max length

### DIFF
--- a/internal/roster/dto.go
+++ b/internal/roster/dto.go
@@ -56,7 +56,7 @@ type CommentCreateRequest struct {
 
 	UserID uint `json:"userId"`
 
-	Comment string `json:"comment"`
+	Comment  string `json:"comment" binding:"required,max=250"`
 } // @name CommentCreateRequest
 
 type SavedShiftUpdateRequest struct {


### PR DESCRIPTION
This updates the DTO of the comments such that the comment itself should only be 250 chars length at max.


## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_