### PR TITLE
fix: post comment request not being upsert

### DIFF
--- a/internal/models/roster.go
+++ b/internal/models/roster.go
@@ -153,10 +153,10 @@ type ShiftGroupPriority struct {
 type RosterComment struct {
 	BaseModel
 
-	RosterID uint `json:"rosterId" gorm:"not null"`
+	RosterID uint `json:"rosterId" gorm:"not null;uniqueIndex:idx_roster_comment_user"`
 	Roster   Roster `json:"-" gorm:"foreignKey:RosterID;constraint:OnDelete:CASCADE;"`
 
-	UserID uint `json:"userId" gorm:"not null"`
+	UserID uint `json:"userId" gorm:"not null;uniqueIndex:idx_roster_comment_user"`
 	User   User `json:"-" gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE;"`
 
 	Comment string `json:"comment" gorm:"type:text"`

--- a/internal/platform/database/migrations/000006_unique_roster_comment_per_user.down.sql
+++ b/internal/platform/database/migrations/000006_unique_roster_comment_per_user.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `roster_comments`
+    DROP INDEX `idx_roster_comment_user`;

--- a/internal/platform/database/migrations/000006_unique_roster_comment_per_user.up.sql
+++ b/internal/platform/database/migrations/000006_unique_roster_comment_per_user.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `roster_comments`
+    ADD UNIQUE KEY `idx_roster_comment_user` (`roster_id`, `user_id`);

--- a/internal/roster/service_comment.go
+++ b/internal/roster/service_comment.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type CommentManager interface {
@@ -32,7 +33,17 @@ func (s *service) CreateRosterComment(params *CommentCreateRequest) (*models.Ros
 		Comment:  params.Comment,
 	}
 
-	if err := s.db.Create(&comment).Error; err != nil {
+	// A user may only have one comment per roster, so re-submitting updates
+	// the existing comment in place instead of creating a duplicate.
+	err := s.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "roster_id"}, {Name: "user_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"comment", "updated_at"}),
+	}).Create(&comment).Error
+	if err != nil {
+		return nil, err
+	}
+
+	if err := s.db.Where("roster_id = ? AND user_id = ?", roster.ID, params.UserID).First(&comment).Error; err != nil {
 		return nil, err
 	}
 

--- a/internal/roster/service_comment_test.go
+++ b/internal/roster/service_comment_test.go
@@ -41,6 +41,50 @@ func (suite *TestRosterSuite) TestCreateRosterComment_Valid() {
 	assert.Equal(suite.T(), roster.ID, comment.RosterID)
 }
 
+func (suite *TestRosterSuite) TestCreateRosterComment_UpdatesExisting() {
+	roster := models.Roster{
+		Name:    "Test Roster",
+		Values:  []string{"yes", "no"},
+		OrganID: uint(1),
+	}
+	suite.db.Create(&roster)
+
+	shift := models.RosterShift{
+		RosterID: roster.ID,
+	}
+	suite.db.Create(&shift)
+
+	suite.db.Create(&models.RosterAnswer{
+		UserID:        1,
+		RosterID:      roster.ID,
+		RosterShiftID: shift.ID,
+		Value:         "yes",
+	})
+
+	first, err := suite.service.CreateRosterComment(&CommentCreateRequest{
+		RosterID: roster.ID,
+		UserID:   1,
+		Comment:  "first comment",
+	})
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), first)
+
+	second, err := suite.service.CreateRosterComment(&CommentCreateRequest{
+		RosterID: roster.ID,
+		UserID:   1,
+		Comment:  "updated comment",
+	})
+	assert.NoError(suite.T(), err)
+	assert.NotNil(suite.T(), second)
+
+	assert.Equal(suite.T(), first.ID, second.ID, "expected the existing comment to be updated, not duplicated")
+	assert.Equal(suite.T(), "updated comment", second.Comment)
+
+	comments, err := suite.service.GetRosterComments(roster.ID)
+	assert.NoError(suite.T(), err)
+	assert.Len(suite.T(), comments, 1, "expected only one comment to remain for this user+roster")
+}
+
 func (suite *TestRosterSuite) TestCreateRosterComment_UserNotInRoster() {
 	roster := models.Roster{
 		Name:    "Test Roster",


### PR DESCRIPTION
The post comment would create a new comment instead of checking for an existing comment and replacing it.

This now also adds an index to the comments between the roster and the user.


## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_