### PR TITLE
fix: user comment allowance check

### DIFF
--- a/internal/roster/service.go
+++ b/internal/roster/service.go
@@ -32,6 +32,7 @@ type Service interface {
 
 type UserProvider interface {
 	Get(*user.FilterParams) ([]*models.User, error)
+	IsUserInOrgan(user *models.User, organID uint) (bool, error)
 }
 
 type service struct {

--- a/internal/roster/service_comment.go
+++ b/internal/roster/service_comment.go
@@ -4,7 +4,6 @@ import (
 	"GEWIS-Rooster/internal/models"
 	"errors"
 	"fmt"
-	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
 
@@ -18,13 +17,17 @@ func (s *service) CreateRosterComment(params *CommentCreateRequest) (*models.Ros
 	if err := s.db.First(&roster, params.RosterID).Error; err != nil {
 		return nil, fmt.Errorf("roster not found: %w", err)
 	}
+	var user *models.User
+	if err := s.db.First(&user, params.UserID).Error; err != nil {
+		return nil, fmt.Errorf("user not found: %w", err)
+	}
 
-	var answer models.RosterAnswer
-	if err := s.db.Where("user_id = ? AND roster_id = ?", params.UserID, params.RosterID).First(&answer).Error; err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, errors.New("user is not part of this roster")
-		}
+	inOrgan, err := s.u.IsUserInOrgan(user, roster.OrganID)
+	if err != nil {
 		return nil, err
+	}
+	if !inOrgan {
+		return nil, errors.New("user is not part of this organ")
 	}
 
 	comment := models.RosterComment{
@@ -35,7 +38,7 @@ func (s *service) CreateRosterComment(params *CommentCreateRequest) (*models.Ros
 
 	// A user may only have one comment per roster, so re-submitting updates
 	// the existing comment in place instead of creating a duplicate.
-	err := s.db.Clauses(clause.OnConflict{
+	err = s.db.Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "roster_id"}, {Name: "user_id"}},
 		DoUpdates: clause.AssignmentColumns([]string{"comment", "updated_at"}),
 	}).Create(&comment).Error

--- a/internal/roster/service_comment_test.go
+++ b/internal/roster/service_comment_test.go
@@ -85,11 +85,14 @@ func (suite *TestRosterSuite) TestCreateRosterComment_UpdatesExisting() {
 	assert.Len(suite.T(), comments, 1, "expected only one comment to remain for this user+roster")
 }
 
-func (suite *TestRosterSuite) TestCreateRosterComment_UserNotInRoster() {
+func (suite *TestRosterSuite) TestCreateRosterComment_UserNotInOrgan() {
+	organ := models.Organ{Name: "Unlinked Organ"}
+	suite.db.Create(&organ)
+
 	roster := models.Roster{
 		Name:    "Test Roster",
 		Values:  []string{"yes", "no"},
-		OrganID: uint(1),
+		OrganID: organ.ID,
 	}
 	suite.db.Create(&roster)
 
@@ -103,7 +106,7 @@ func (suite *TestRosterSuite) TestCreateRosterComment_UserNotInRoster() {
 
 	assert.Error(suite.T(), err)
 	assert.Nil(suite.T(), comment)
-	assert.Contains(suite.T(), err.Error(), "not part of this roster")
+	assert.Contains(suite.T(), err.Error(), "not part of this organ")
 }
 
 func (suite *TestRosterSuite) TestCreateRosterComment_RosterNotFound() {
@@ -134,14 +137,6 @@ func (suite *TestRosterSuite) TestGetRosterComments_FiltersByRoster() {
 		OrganID: uint(1),
 	}
 	suite.db.Create(&rosterTwo)
-
-	shiftOne := models.RosterShift{RosterID: rosterOne.ID}
-	suite.db.Create(&shiftOne)
-	shiftTwo := models.RosterShift{RosterID: rosterTwo.ID}
-	suite.db.Create(&shiftTwo)
-
-	suite.db.Create(&models.RosterAnswer{UserID: 1, RosterID: rosterOne.ID, RosterShiftID: shiftOne.ID, Value: "yes"})
-	suite.db.Create(&models.RosterAnswer{UserID: 1, RosterID: rosterTwo.ID, RosterShiftID: shiftTwo.ID, Value: "yes"})
 
 	_, err := suite.service.CreateRosterComment(&CommentCreateRequest{RosterID: rosterOne.ID, UserID: 1, Comment: "comment one"})
 	assert.NoError(suite.T(), err)

--- a/internal/roster/service_test.go
+++ b/internal/roster/service_test.go
@@ -3,6 +3,7 @@ package roster
 import (
 	"GEWIS-Rooster/cmd/seeder/seeder"
 	"GEWIS-Rooster/internal/models"
+	"GEWIS-Rooster/internal/user"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
@@ -19,7 +20,7 @@ type TestRosterSuite struct {
 func (suite *TestRosterSuite) SetupTest() {
 	db := seeder.Seeder(":memory:")
 	suite.db = db
-	suite.service = service{db: db}
+	suite.service = service{db: db, u: user.NewUserService(db)}
 }
 
 // service_roster.go test cases

--- a/internal/user/service.go
+++ b/internal/user/service.go
@@ -11,6 +11,7 @@ type Service interface {
 	Create(*CreateRequest) (*models.User, error)
 	Get(*FilterParams) ([]*models.User, error)
 	Delete(uint) error
+	IsUserInOrgan(user *models.User, organID uint) (bool, error)
 }
 
 type service struct {
@@ -82,4 +83,20 @@ func (s *service) Delete(ID uint) error {
 	}
 
 	return nil
+}
+
+// IsUserInOrgan checks organ membership via the user_organs join table directly,
+// rather than the user's Organs association, since callers may not have preloaded it.
+func (s *service) IsUserInOrgan(u *models.User, organID uint) (bool, error) {
+	err := s.db.Where("user_id = ? AND organ_id = ?", u.ID, organID).
+		First(&models.UserOrgan{}).Error
+
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
 }


### PR DESCRIPTION
We were checking if the user had an answer in a roster and then being allowed to make a comment. Meaning you could not comment if you did not fill anything in.

We change this by adding a aIsUserInOrgan function in the user service file. by checking the user organs mebermship.

## Types of changes
<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->
- Bug fix _(non-breaking change which fixes an issue)_